### PR TITLE
Add type checking script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,12 @@ _The most valuable commodity I know of is information._
 -Bud Fox
 
 Fox is a CLI utility that generates YAML configs and spins up parallel workers to back-test Gekko trading strategies. It is written in Typescript and runs on [Bun](https://bun.sh/).
+
+## Available Scripts
+
+- `bun run build` - build the project
+- `bun run dev` - run the CLI in development mode
+- `bun run test` - run the test suite
+- `bun run test:watch` - watch tests for changes
+- `bun run test:coverage` - generate a coverage report
+- `bun run type:check` - run TypeScript type checking

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
+    "type:check": "tsc --noEmit",
     "dev": "bun src/index.ts"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `type:check` script to run TypeScript compiler in noEmit mode
- list available scripts including `type:check` in README

## Testing
- `bun run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845b3b35d90832e937267a24f3f5603