### PR TITLE
Add format:check script with Prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 ![Bud Fox](https://github.com/user-attachments/assets/bf70231b-81ad-4c0f-a272-51a63928c1c3)
 
-
 _The most valuable commodity I know of is information._
 
 -Bud Fox

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "private": false,
   "scripts": {
     "build": "bun build src/fox.ts --outdir=dist --minify",
-    "test": "vitest --run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage",
-    "type:check": "tsc --noEmit",
     "dev": "bun src/fox.ts",
-    "prepare": "husky install"
+    "format": "prettier --write \"./**/*.{cjs,js,ts,yml,json,md}\"",
+    "format:check": "prettier --check \"./**/*.{cjs,js,ts,yml,json,md}\"",
+    "prepare": "husky install",
+    "test": "vitest --run",
+    "test:coverage": "vitest run --coverage",
+    "test:watch": "vitest",
+    "type:check": "tsc --noEmit"
   },
   "devDependencies": {
     "@types/bun": "latest",
@@ -24,7 +26,7 @@
     "@commitlint/config-conventional": "^18.6.0"
   },
   "lint-staged": {
-    "*.{ts,js,json,yml,md}": [
+    "*.{cjs,ts,js,json,yml,md}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
## Summary
- add a format:check script to package.json so devs can verify formatting with Prettier

## Testing
- `bun run test`
- `bun run format:check` *(fails: README.md is not formatted)*

------
https://chatgpt.com/codex/tasks/task_e_6845fb44e398832eb388bb8a0cdb9802