### PR TITLE
Add metadata fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,23 @@
   "module": "fox.ts",
   "type": "module",
   "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/youtix/fox.git"
+  },
+  "homepage": "https://github.com/youtix/fox#readme",
+  "bugs": {
+    "url": "https://github.com/youtix/fox/issues"
+  },
+  "author": "youtix",
+  "license": "MIT",
+  "keywords": [
+    "backtest",
+    "gekko2",
+    "gekko",
+    "trading",
+    "bun"
+  ],
   "scripts": {
     "build": "bun build src/fox.ts --outdir=dist --minify",
     "commit:check": "commitlint --from=HEAD~10",


### PR DESCRIPTION
## Summary
- make `package.json` consumer friendly by adding repository link, homepage link, bugs url
- set author, license and keywords to document the package

## Testing
- `bun run test`


------
https://chatgpt.com/codex/tasks/task_e_6846e9b26260832eaca7e54f744a5006