### PR TITLE
Fix commitlint release failure

### DIFF
--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,3 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    'body-max-line-length': [0, 'always'],
+  },
 };


### PR DESCRIPTION
## Summary
- disable commitlint body-length check to allow semantic-release commit messages

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_684701f94e10832e879c364843baf9e0