### PR TITLE
Upload build artifact to release

### DIFF
--- a/release.config.cjs
+++ b/release.config.cjs
@@ -9,7 +9,12 @@ module.exports = {
         changelogFile: 'CHANGELOG.md',
       },
     ],
-    '@semantic-release/github',
+    [
+      '@semantic-release/github',
+      {
+        assets: ['dist/fox'],
+      },
+    ],
     [
       '@semantic-release/git',
       {


### PR DESCRIPTION
## Summary
- upload the built `fox` binary on release
- export `GITHUB_TOKEN` in workflow for semantic-release
- remove redundant `GH_TOKEN`

## Testing
- `bun install --frozen-lockfile`
- `bun run lint:check`
- `bun run test:coverage`
- `bun run build`
- `bun run release --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_68493f941fe0832eb0838f0a998a6921